### PR TITLE
Adjust tuning for argon2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ docker_builder:
         HOME: /root
         DEBIAN_FRONTEND: noninteractive
         CIRRUS_LOG_TIMESTAMP: true
-        GOMEMLIMIT: "1GiB"
     setup_script: |
         apt-get -q update
         apt-get -q install -y bats cryptsetup golang

--- a/encrypt.go
+++ b/encrypt.go
@@ -246,8 +246,8 @@ func EncryptV2(password []string, cipher string, payloadSectorSize int) ([]byte,
 		return nil, nil, -1, errors.New("internal error")
 	}
 	iterations := IterationsPBKDF2(tuningSalt, len(mkey), hasher)
-	timeCost := 1
-	threadsCost := 4
+	timeCost := 16
+	threadsCost := 16
 	memoryCost := MemoryCostArgon2(tuningSalt, len(mkey), timeCost, threadsCost)
 	priority := V2JSONKeyslotPriorityNormal
 	var stripes [][]byte


### PR DESCRIPTION
Adjust tuning for argon2 to use more cpu/threads so that unit tests don't swell to more memory than is available in CI, and presumably end systems.