### PR TITLE
memoryCostArgon2(): be more careful with integer math for 32-bit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,23 @@ docker_builder:
         apt-get -q install -y bats cryptsetup golang
         go version
         make
-    unit_test_script:
+    unit_test_script: |
         go test -timeout 45m -v -cover
+        case $(go env GOARCH) in
+        amd64)
+          otherarch=386;;
+        arm64)
+          otherarch=arm;;
+        mips64)
+          otherarch=mips;;
+        mips64le)
+          otherarch=mipsle;;
+        esac
+        if test -n "$otherarch" ; then
+          echo running unit tests again with GOARCH=$otherarch
+          GOARCH=$otherarch go test -timeout 45m -v -cover
+        fi
+        :
     defaults_script: |
         bats -f defaults ./tests
     aes_script: |

--- a/tune.go
+++ b/tune.go
@@ -40,7 +40,7 @@ func memoryCostArgon2(salt []byte, keyLen, timeCost, threadsCost int, kdf func([
 		if d < time.Second/10 {
 			memoryCost *= 2
 		} else {
-			return memoryCost * int(time.Second) / int(d)
+			return memoryCost * int(float64(time.Second)/float64(d))
 		}
 	}
 	return memoryCost


### PR DESCRIPTION
Some of the integer math we were doing in memoryCostArgon2() was wrapping around on 32-bit architectures.  Cast to float while we're doing that, and have unit tests run for a 32-bit architecture if we're on a 64-bit system and think we can run corresponding 32-bit code.