### PR TITLE
Update to go 1.21

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,9 +4,11 @@ docker_builder:
         HOME: /root
         DEBIAN_FRONTEND: noninteractive
         CIRRUS_LOG_TIMESTAMP: true
+        GOVERSION: 1.21
+        PATH: /usr/lib/go-1.21/bin:$PATH
     setup_script: |
         apt-get -q update
-        apt-get -q install -y bats cryptsetup golang
+        apt-get -q install -y bats cryptsetup golang-${GOVERSION}
         go version
         make
     unit_test_script: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/luksy
 
-go 1.20
+go 1.21
 
 require (
 	github.com/aead/serpent v0.0.0-20160714141033-fba169763ea6


### PR DESCRIPTION
Install the go-1.21 package during CI runs, and require it in go.mod, so that when we pull in dependency updates that expect the standard library to include a "slices" or "maps" package, we can still compile.